### PR TITLE
feat: Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "fankserver"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      discord:
+        patterns:
+          - "github.com/bwmarrin/discordgo"
+          - "layeh.com/gopus"
+      logging:
+        patterns:
+          - "github.com/sirupsen/logrus"
+      utilities:
+        patterns:
+          - "github.com/google/uuid"
+          - "github.com/joho/godotenv"
+      # MCP SDK kept separate due to experimental status
+      # It will create individual PRs
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    reviewers:
+      - "fankserver"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    reviewers:
+      - "fankserver"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration to automate dependency updates
- Groups Go packages logically for cleaner PR management
- Configures weekly update schedule for all ecosystems

## Changes
- **Go modules**: Grouped into discord, logging, and utilities categories
- **MCP SDK**: Kept separate due to experimental status (individual PRs)
- **Docker**: Weekly updates for base images
- **GitHub Actions**: Weekly updates for workflow dependencies

## Configuration Details
- Weekly updates scheduled for Monday at 3:00 AM
- Maximum 10 open PRs at a time
- Appropriate labels applied (dependencies, go, docker, github-actions)
- Commit messages use conventional commit format with `chore` prefix

## Test Plan
- [ ] Dependabot will validate configuration upon merge
- [ ] First dependency check will run on next Monday
- [ ] Monitor initial PRs to ensure grouping works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)